### PR TITLE
Add reload command

### DIFF
--- a/load.py
+++ b/load.py
@@ -1,4 +1,13 @@
+import sys
+prefix = __package__ + '.'  # don't clear the base package
+for module_name in [
+        module_name for module_name in sys.modules
+        if module_name.startswith(prefix) and module_name != __name__]:
+    del sys.modules[module_name]
+del prefix
+
 from .src.api import (  # noqa: F401
+    TreeSitterReloadCommand,
     TreeSitterGotoSymbolCommand,
     TreeSitterOnSelectionModifiedListener,
     TreeSitterPrintTreeCommand,

--- a/src/api.py
+++ b/src/api.py
@@ -20,7 +20,16 @@ from .core import (
     publish_tree_update,
     trim_cached_trees,
 )
-from .utils import QUERIES_PATH, get_debug, get_queries_path, get_scope_to_language_name, log, maybe_none, not_none
+from .utils import (
+    PROJECT_ROOT,
+    QUERIES_PATH,
+    get_debug,
+    get_queries_path,
+    get_scope_to_language_name,
+    log,
+    maybe_none,
+    not_none,
+)
 
 if TYPE_CHECKING:
     from tree_sitter import Node, Tree
@@ -859,6 +868,12 @@ class TreeSitterSelectSymbolsCommand(sublime_plugin.TextCommand):
             sel.clear()
             for capture in captures:
                 sel.add(get_region_from_node(capture["node"], self.view))
+
+
+class TreeSitterReloadCommand(sublime_plugin.ApplicationCommand):
+    def run(self):
+        root_file = Path(PROJECT_ROOT) / "load.py"
+        root_file.touch()
 
 
 class TreeSitterGotoSymbolCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
Patch `load.py` (our root module) to reload everything when it loads. This is for example the case when a user receives an update from Package Control in the future.

Add `TreeSitterReloadCommand` to mimic touching `load.py`.  Typically you set in the project settings

```
{
    "build_systems":
    [
        {
            "name": "Reload TreeSitter",
            "target": "tree_sitter_reload"
        },
    ],
    "folders": [
        {
            "path": "."
        },
    ],
    "settings": {
	}
}

```

and then reload on-demand using `ctrl+b`.