### PR TITLE
Exclude development related files from package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# git
+.github/                export-ignore
+.gitattributes          export-ignore
+.gitignore              export-ignore
+
+# unittests
+pre-push                export-ignore
+pyrightconfig-ci.json   export-ignore
+ruff.toml               export-ignore


### PR DESCRIPTION
This commit adds .gitattributes file to exclude some dev-only related files from production package.