### PR TITLE
Adjust Command Palette Settings label

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,6 +1,6 @@
 [
   {
-    "caption": "TreeSitter: Settings",
+    "caption": "Preferences: TreeSitter Settings",
     "command": "edit_settings",
     "args": {
       "base_file": "${packages}/TreeSitter/TreeSitter.sublime-settings",


### PR DESCRIPTION
This commit adjusts settings label to make it follow ST's common naming scheme.

Preferences entries of all packages should start with `Preferences: `.