### PR TITLE
Add `file_ignore_patterns` setting

### DIFF
--- a/load.py
+++ b/load.py
@@ -1,6 +1,6 @@
 import sys
 
-prefix = __package__ + "."  # Don't clear the base package
+prefix = __package__ + "."  # type: ignore # Don't clear the base package
 for module_name in [
     module_name for module_name in sys.modules if module_name.startswith(prefix) and module_name != __name__
 ]:

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -101,6 +101,13 @@
               "type": "string",
               "markdownDescription": "Path to queries files for all languages"
             },
+            "file_ignore_patterns": {
+              "type": "array",
+              "items": {
+                  "type": "string"
+              },
+              "markdownDescription": "If file matches any of these regex patterns, ignore it (useful for e.g. files that cause Tree-sitter parse errors)"
+            },
             "debug": {
               "type": "boolean",
               "markdownDescription": "Enable debug logging and assertions; has non-zero performance cost, for developers only"


### PR DESCRIPTION
- Add `file_ignore_patterns` setting
  - Lets users specify regex(es) to ignore file paths that cause trouble for a language parser
- Internal: simplified settings management with improved perf